### PR TITLE
Make the 'expired' event only emit 1 argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ module.exports = function Expirer(timeoutMs, db, checkIntervalMs) {
 
 			db.batch(batchObjects, function(err) {
 				if (!err) {
-					filterForgotten(expiringNow).forEach(expirer.emit.bind(expirer, 'expire'))
+					filterForgotten(expiringNow).forEach(function (key) { expirer.emit('expire', key) })
 				}
 				forgotten = []
 				done(err)

--- a/test/expired_event_emits_1_arg.js
+++ b/test/expired_event_emits_1_arg.js
@@ -1,0 +1,21 @@
+var Expirer = require('../')
+var test = require('tape')
+var level = require('level-mem')
+
+test('an expired event should only have 1 argument', function(t) {
+	t.timeoutAfter(2000)
+	t.plan(2)
+
+	var expirer = new Expirer(100, level('roflcopter'))
+
+	expirer.emit('touch', 'hello there')
+
+	expirer.on('expire', function() {
+		var argArray = Array.prototype.slice.call(arguments)
+		t.equal(argArray.length, 1, 'should only have 1 argument')
+		t.equal(argArray[0], 'hello there')
+
+		expirer.stop()
+		t.end()
+	})
+})


### PR DESCRIPTION
Make the 'expired' event only emit 1 argument

Fixes #4.