### PR TITLE
Modernizing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
-  - "9"
+  - "10"
   - "8"
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "5.0"
-  - "4.0"
-  - "0.12"
+  - "9"
+  - "8"
 sudo: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,698 @@
+{
+  "name": "expire-unused-keys",
+  "version": "1.4.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "abstract-leveldown": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
+      "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
+      "dev": true,
+      "requires": {
+        "xtend": "4.0.1"
+      }
+    },
+    "array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "better-emitter": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/better-emitter/-/better-emitter-1.0.2.tgz",
+      "integrity": "sha512-Q/rkwZoL4tN3F1hZZOvTHgEhVoCkLN9asHiOOYFd+4hEnNFbpTyRAUheYIGF6UxCcc7evVQRO+w/DQd4dqiEww==",
+      "requires": {
+        "key-master": "3.1.0"
+      }
+    },
+    "bl": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-0.8.2.tgz",
+      "integrity": "sha1-yba8oI0bwuoA/Ir7Txpf0eHGbk4=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "1.0.34"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        }
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "currently-unhandled": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+      "dev": true,
+      "requires": {
+        "array-find-index": "1.0.2"
+      }
+    },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+      "dev": true
+    },
+    "define-properties": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "dev": true,
+      "requires": {
+        "foreach": "2.0.5",
+        "object-keys": "1.0.11"
+      }
+    },
+    "defined": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+      "dev": true
+    },
+    "delay": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/delay/-/delay-2.0.0.tgz",
+      "integrity": "sha1-kRLq3APk7H4AKXM3iW8nO72R+uU=",
+      "dev": true,
+      "requires": {
+        "p-defer": "1.0.0"
+      }
+    },
+    "encoding-down": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-2.3.4.tgz",
+      "integrity": "sha1-jsJ3Ka6tB5gUSiaJ/aifMDqTpeM=",
+      "dev": true,
+      "requires": {
+        "abstract-leveldown": "2.7.2",
+        "level-codec": "8.0.0",
+        "level-errors": "1.1.1"
+      }
+    },
+    "errno": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+      "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
+      "dev": true,
+      "requires": {
+        "prr": "0.0.0"
+      }
+    },
+    "es-abstract": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.9.0.tgz",
+      "integrity": "sha512-kk3IJoKo7A3pWJc0OV8yZ/VEX2oSUytfekrJiqoxBlKJMFAJVJVpGdHClCCTdv+Fn2zHfpDHHIelMFhZVfef3Q==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "1.1.1",
+        "function-bind": "1.1.1",
+        "has": "1.0.1",
+        "is-callable": "1.1.3",
+        "is-regex": "1.0.4"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+      "dev": true,
+      "requires": {
+        "is-callable": "1.1.3",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.1"
+      }
+    },
+    "externr": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/externr/-/externr-1.0.0.tgz",
+      "integrity": "sha1-4qdB98+aN/6ZGaAqVgsKCv5/oLo=",
+      "dev": true
+    },
+    "for-each": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz",
+      "integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ=",
+      "dev": true,
+      "requires": {
+        "is-function": "1.0.1"
+      }
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "has": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "dev": true,
+      "requires": {
+        "function-bind": "1.1.1"
+      }
+    },
+    "immediate": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
+      "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "is-callable": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+      "dev": true
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
+    },
+    "is-function": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
+      "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU=",
+      "dev": true
+    },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "requires": {
+        "has": "1.0.1"
+      }
+    },
+    "is-symbol": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
+      "dev": true
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
+    },
+    "iso-next-tick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/iso-next-tick/-/iso-next-tick-1.0.0.tgz",
+      "integrity": "sha1-sADF3PYv0E/9r3dU3ncaEqbbgvA="
+    },
+    "key-master": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/key-master/-/key-master-3.1.0.tgz",
+      "integrity": "sha512-peu6Yj3avUJUHLd2ES1NMNEtOkaJPn9BTwIJ0z1ah9CiSUwymuy6uQroPv3FcbFIlLtOKAo6dqVSEZZaY0HmYQ=="
+    },
+    "level-codec": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-8.0.0.tgz",
+      "integrity": "sha512-gNZlo1HRHz0BWxzGCyNf7xntAs2HKOPvvRBWtXsoDvEX4vMYnSTBS6ZnxoaiX7nhxSBPpegRa8CQ/hnfGBKk3Q==",
+      "dev": true
+    },
+    "level-errors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.1.1.tgz",
+      "integrity": "sha512-9MIIbizlJgWFQ6m45ehVuSrpzFxwJQmZYD6sfmiizhdmWMNUf41mBYpUJEeCslIa3sB4vdsIFCimPdDZkWznwA==",
+      "dev": true,
+      "requires": {
+        "errno": "0.1.4"
+      }
+    },
+    "level-iterator-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-2.0.0.tgz",
+      "integrity": "sha512-TWOYw8HR5mhj6xwoVLo0yu26RPL6v28KgvhK1kY1CJf9LyL+rJXjx99zhORTYhN9ysOBIH+iaxAiqRteA+C1/g==",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3",
+        "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.0.3",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        }
+      }
+    },
+    "level-spaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/level-spaces/-/level-spaces-2.0.1.tgz",
+      "integrity": "sha1-3OwlsoMmMDSLm+pamP6IcKtcTQI=",
+      "dev": true,
+      "requires": {
+        "level-updown": "2.0.2",
+        "levelup": "0.19.1",
+        "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "abstract-leveldown": {
+          "version": "0.12.4",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz",
+          "integrity": "sha1-KeGOYy5g5OIh1YECR4UqY9ey5BA=",
+          "dev": true,
+          "requires": {
+            "xtend": "3.0.0"
+          },
+          "dependencies": {
+            "xtend": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+              "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo=",
+              "dev": true
+            }
+          }
+        },
+        "deferred-leveldown": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-0.2.0.tgz",
+          "integrity": "sha1-LO8fER4cV4cNi7uK8mUOWHzS9bQ=",
+          "dev": true,
+          "requires": {
+            "abstract-leveldown": "0.12.4"
+          }
+        },
+        "levelup": {
+          "version": "0.19.1",
+          "resolved": "https://registry.npmjs.org/levelup/-/levelup-0.19.1.tgz",
+          "integrity": "sha1-86anIFJyxLXzXkEv8ASgOgrt9Qs=",
+          "dev": true,
+          "requires": {
+            "bl": "0.8.2",
+            "deferred-leveldown": "0.2.0",
+            "errno": "0.1.4",
+            "prr": "0.0.0",
+            "readable-stream": "1.0.34",
+            "semver": "5.1.1",
+            "xtend": "3.0.0"
+          },
+          "dependencies": {
+            "xtend": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+              "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo=",
+              "dev": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "semver": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.1.tgz",
+          "integrity": "sha1-oykqNz5vPgeY2gsgZBuanFvEfhk=",
+          "dev": true
+        }
+      }
+    },
+    "level-updown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/level-updown/-/level-updown-2.0.2.tgz",
+      "integrity": "sha1-vquHaCTDGrjbe/LBnFWDypFsezA=",
+      "dev": true,
+      "requires": {
+        "abstract-leveldown": "0.12.4",
+        "externr": "1.0.0",
+        "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "abstract-leveldown": {
+          "version": "0.12.4",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz",
+          "integrity": "sha1-KeGOYy5g5OIh1YECR4UqY9ey5BA=",
+          "dev": true,
+          "requires": {
+            "xtend": "3.0.0"
+          },
+          "dependencies": {
+            "xtend": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+              "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo=",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "levelup": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/levelup/-/levelup-2.0.0.tgz",
+      "integrity": "sha512-0yfH17VjEgdeVYYrCBwlLStJEKpzj5j4WRDKjMWkby5zwgY/HcHiH4VukHsyMH4HyectVljpATCD4Pcbk5md6w==",
+      "dev": true,
+      "requires": {
+        "deferred-leveldown": "2.0.3",
+        "level-errors": "1.1.1",
+        "level-iterator-stream": "2.0.0",
+        "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "abstract-leveldown": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-3.0.0.tgz",
+          "integrity": "sha512-KUWx9UWGQD12zsmLNj64/pndaz4iJh/Pj7nopgkfDG6RlCcbMZvT6+9l7dchK4idog2Is8VdC/PvNbFuFmalIQ==",
+          "dev": true,
+          "requires": {
+            "xtend": "4.0.1"
+          }
+        },
+        "deferred-leveldown": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-2.0.3.tgz",
+          "integrity": "sha512-8c2Hv+vIwKNc7qqy4zE3t5DIsln+FQnudcyjLYstHwLFg7XnXZT/H8gQb8lj6xi8xqGM0Bz633ZWcCkonycBTA==",
+          "dev": true,
+          "requires": {
+            "abstract-leveldown": "3.0.0"
+          }
+        }
+      }
+    },
+    "loud-rejection": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+      "dev": true,
+      "requires": {
+        "currently-unhandled": "0.4.1",
+        "signal-exit": "3.0.2"
+      }
+    },
+    "ltgt": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.0.tgz",
+      "integrity": "sha1-tlul/LNJopkkyOMz98alVi8uSEI=",
+      "dev": true
+    },
+    "memdown": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
+      "integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
+      "dev": true,
+      "requires": {
+        "abstract-leveldown": "2.7.2",
+        "functional-red-black-tree": "1.0.1",
+        "immediate": "3.2.3",
+        "inherits": "2.0.3",
+        "ltgt": "2.2.0",
+        "safe-buffer": "5.1.1"
+      },
+      "dependencies": {
+        "abstract-leveldown": {
+          "version": "2.7.2",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
+          "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
+          "dev": true,
+          "requires": {
+            "xtend": "4.0.1"
+          }
+        }
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
+    },
+    "object-inspect": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.3.0.tgz",
+      "integrity": "sha512-OHHnLgLNXpM++GnJRyyhbr2bwl3pPVm4YvaraHrRvDt/N3r+s/gDVHciA7EJBTkijKXj61ssgSAikq1fb0IBRg==",
+      "dev": true
+    },
+    "object-keys": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "p-defer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+      "dev": true
+    },
+    "prr": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
+      "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=",
+      "dev": true
+    },
+    "resolve": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
+      "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
+      "dev": true,
+      "requires": {
+        "path-parse": "1.0.5"
+      }
+    },
+    "resumer": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
+      "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
+      "dev": true,
+      "requires": {
+        "through": "2.3.8"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "string.prototype.trim": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
+      "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.9.0",
+        "function-bind": "1.1.1"
+      }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
+    },
+    "tape": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-4.8.0.tgz",
+      "integrity": "sha512-TWILfEnvO7I8mFe35d98F6T5fbLaEtbFTG/lxWvid8qDfFTxt19EBijWmB4j3+Hoh5TfHE2faWs73ua+EphuBA==",
+      "dev": true,
+      "requires": {
+        "deep-equal": "1.0.1",
+        "defined": "1.0.0",
+        "for-each": "0.3.2",
+        "function-bind": "1.1.1",
+        "glob": "7.1.2",
+        "has": "1.0.1",
+        "inherits": "2.0.3",
+        "minimist": "1.2.0",
+        "object-inspect": "1.3.0",
+        "resolve": "1.4.0",
+        "resumer": "0.0.0",
+        "string.prototype.trim": "1.1.2",
+        "through": "2.3.8"
+      }
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -13,9 +13,13 @@
     "url": "https://github.com/TehShrike/expire-unused-keys.git"
   },
   "devDependencies": {
-    "level-mem": "~0.18.0",
-    "level-spaces": "^2.0.0",
-    "tape": "^4.0.0"
+    "delay": "2.0.0",
+    "encoding-down": "2.3.4",
+    "level-spaces": "2.0.1",
+    "levelup": "2.0.0",
+    "loud-rejection": "1.6.0",
+    "memdown": "1.4.1",
+    "tape": "4.8.0"
   },
   "directories": {
     "test": "test"
@@ -23,5 +27,9 @@
   "scripts": {
     "test": "tape ./test/*.js"
   },
-  "license": "WTFPL"
+  "license": "WTFPL",
+  "dependencies": {
+    "better-emitter": "1.0.2",
+    "iso-next-tick": "1.0.0"
+  }
 }

--- a/readme.md
+++ b/readme.md
@@ -64,7 +64,7 @@ const expireUnusedKeys = require('expire-unused-keys')
 ## `expirer = expireUnusedKeys({ timeoutMs, db, [checkIntervalMs,] [repeatExpirations] })`
 
 - timeoutMs: how many milliseconds the object will wait before it emits an 'expire' event for a touched key
-- db: a LevelUP data store of some kind
+- db: a LevelUP data store of some kind.  Must be wrapped by `encoding-down` or some other encoder that is cool with strings and numbers.
 - checkIntervalMs: right now, this library works by iterating over all keys and emitting expire events for any items that were last touched timeoutMs ago.  This value prescribes how often the keys should be iterated over.  Defaults to 1000.
 - repeatExpirations: set to true to emit 'expire' events for keys every `timeoutMs` milliseconds. By default, keys will be forgotten at the first 'expire' event.
 

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,7 @@
 [![Build Status](https://travis-ci.org/TehShrike/expire-unused-keys.svg)](https://travis-ci.org/TehShrike/expire-unused-keys)
 
+# expire-unused-keys
+
 So I'm writing this other library that needs to do some basic caching, right?  You know - the [first hard thing](http://martinfowler.com/bliki/TwoHardThings.html).  (For an idea of my work on the second hard thing, see the examples below.)
 
 It's not so much that I need flotsam deleted right away when it expires as I want the value to be refreshed every so often, and if that value goes a long enough time with out being accessed, theeeeen I'll drop it.
@@ -8,55 +10,58 @@ To lessen the pain in this task, I need a library that will keep track of what t
 
 It stores last-access times in a [LevelUP](https://github.com/rvagg/node-levelup) db - if you don't need persistence, throw [level-mem](https://github.com/Level/level-mem) at it.
 
-Example
-=====
+## breaking changes: version 2.x
+
+- Only tested with LevelUP 2.x
+- Ordered arguments to the constructor are no longer accepted, you gotta pass in an object
+- Emitting events on the expirer object can no longer be done as a proxy for calling the functions
+- All functions return promises
+- Uses Promise + Set + ES2017, polyfill/transpile as needed
+
+# Example
 
 ```js
-    // Some levelUP db
-	var db = level('wat')
-	// Expire stuff after 15 seconds of inactivity
-	var expirer = new Expirer(15000, db)
+// Expire stuff after 15 seconds of inactivity
+const expirer = new Expirer(15 * 1000, someLevelUpDb)
 
-	// Things are only interesting if they were active in the last 15 seconds
-	var areTheseThingsInteresting = {
-		'thing1': false,
-		'thing2': false
-	}
+// Things are only interesting if they were active in the last 15 seconds
+const areTheseThingsInteresting = {
+	'thing1': false,
+	'thing2': false
+}
 
-	var activity = function(thingKey) {
-		areTheseThingsInteresting[thingKey] = true
+const activity = function(thingKey) {
+	areTheseThingsInteresting[thingKey] = true
 
-		// note that this thing was fiddled with
-		expirer.touch(thingKey)
-	}
+	// note that this thing was fiddled with
+	expirer.touch(thingKey)
+}
 
-	expirer.on('expire', function(thingKey) {
-		console.log(thingKey + " expired!")
-		areTheseThingsInteresting[thingKey] = false
-	})
+expirer.on('expire', function(thingKey) {
+	console.log(thingKey + " expired!")
+	areTheseThingsInteresting[thingKey] = false
+})
 
+activity('thing1')
+activity('thing2')
+
+setTimeout(function() {
 	activity('thing1')
-	activity('thing2')
+}, 10 * 1000)
 
-	setTimeout(function() {
-		activity('thing1')
-	}, 10 * 1000)
-
-    // thing1 will expire after 25 seconds after the first time it was touched
-    // thing2 will expire 15 seconds after the first time it was touched
+ // thing1 will expire after 25 seconds after the first time it was touched
+ // thing2 will expire 15 seconds after the first time it was touched
 ```
 
-Usage
-=====
+# API
 
 The module returns a constructor function:
 
 ```js
-var expireUnusedKeys = require('expire-unused-keys')
+const expireUnusedKeys = require('expire-unused-keys')
 ```
 
-## expireUnusedKeys(timeoutMs, db, [checkIntervalMs]) - *Backwards compatibility*
-## expireUnusedKeys({ timeoutMs, db, [checkIntervalMs,] [repeatExpirations] })
+## `expirer = expireUnusedKeys({ timeoutMs, db, [checkIntervalMs,] [repeatExpirations] })`
 
 - timeoutMs: how many milliseconds the object will wait before it emits an 'expire' event for a touched key
 - db: a LevelUP data store of some kind
@@ -65,23 +70,33 @@ var expireUnusedKeys = require('expire-unused-keys')
 
 The resulting object is an EventEmitter with the following functions as properties:
 
-## touch(key)
+## `promise = expirer.touch(key)`
 
 Updates the "last touched" timestamp.  Expire events will not fire for a key until at least timeoutMs after the last time the key was touched.
 
-## forget(key[, cb])
+## `promise = expirer.forget(key[, cb])`
 
 Forgets about a key.  Won't fire any expire events for it (unless you touch that key again).
 
-## createIfNotExists(key)
+## `promise = expirer.createIfNotExists(key)`
 
 Creates it if it doesn't exist yet. If you called `touch` on the key without calling `forget` since, this will not create the key. If you have never called `touch`, or have called `forget` since, this will update the timestamp just like calling `touch`.
 
 *Note:* It is possible to create a race condition if you call `touch` and `createIfNotExists` around the same time on a key that doesn't exist yet. In that case, the key will be created, and the timestamp will be updated once or twice around the same time.
 
-## stop()
+## `expirer.stop()`
 
 Shuts down any timeouts that are floating around, letting you shut down your server nicely and stuff.
+
+# Events emitted
+
+`expirer` is an event emitter with a [better-emitter](https://github.com/TehShrike/better-emitter) interface.
+
+All events emit a single argument: they relevant key string.
+
+- `expire`: emits the key that should be expired
+- `touch`: emits when a key is touched and its expiration time is moved out
+- `forget`: emits when a key is forgotten
 
 License
 -----

--- a/readme.md
+++ b/readme.md
@@ -21,8 +21,10 @@ It stores last-access times in a [LevelUP](https://github.com/rvagg/node-levelup
 # Example
 
 ```js
+const expireUnusedKeys = require('expire-unused-keys')
+
 // Expire stuff after 15 seconds of inactivity
-const expirer = new Expirer(15 * 1000, someLevelUpDb)
+const expirer = expireUnusedKeys({ timeoutMs: 15 * 1000, db: someLevelUpDb })
 
 // Things are only interesting if they were active in the last 15 seconds
 const areTheseThingsInteresting = {
@@ -30,14 +32,14 @@ const areTheseThingsInteresting = {
 	'thing2': false
 }
 
-const activity = function(thingKey) {
+function activity(thingKey) {
 	areTheseThingsInteresting[thingKey] = true
 
 	// note that this thing was fiddled with
 	expirer.touch(thingKey)
 }
 
-expirer.on('expire', function(thingKey) {
+expirer.on('expire', thingKey => {
 	console.log(thingKey + " expired!")
 	areTheseThingsInteresting[thingKey] = false
 })
@@ -45,9 +47,7 @@ expirer.on('expire', function(thingKey) {
 activity('thing1')
 activity('thing2')
 
-setTimeout(function() {
-	activity('thing1')
-}, 10 * 1000)
+setTimeout(() => activity('thing1'), 10 * 1000)
 
  // thing1 will expire after 25 seconds after the first time it was touched
  // thing2 will expire 15 seconds after the first time it was touched

--- a/test/create_if_not_exists.js
+++ b/test/create_if_not_exists.js
@@ -1,27 +1,27 @@
+require('loud-rejection')()
+const makeDb = require('./helpers/level-mem')
 var Expirer = require('../')
 var test = require('tape')
-var level = require('level-mem')
 
-test('create key if it doesn\'t exist yet', function(t) {
+test('create key if it doesn\'t exist yet', async function(t) {
 	var expirer = new Expirer({
 		timeoutMs: 5000,
-		db: level('wat')
+		db: makeDb('watever'),
 	})
 
 	t.plan(1)
 
-	expirer.touch('old')
+	await expirer.touch('old')
 
-	expirer.once('touch', function(key) {
+	expirer.once('touch', key => {
+		console.log('touched', key)
 		t.equal(key, 'new')
 		t.end()
 	})
 
-	setTimeout(function () {
-		expirer.createIfNotExists('old')
-	}, 100)
-	
-	setTimeout(function () {
-		expirer.createIfNotExists('new')
-	}, 200)
+	console.log('here')
+
+	await expirer.createIfNotExists('old')
+
+	await expirer.createIfNotExists('new')
 })

--- a/test/example.js
+++ b/test/example.js
@@ -1,19 +1,20 @@
+require('loud-rejection')()
 var test = require('tape')
-var level = require('level-mem')
+const level = require('./helpers/level-mem')
 
 var Expirer = require('../')
 // var Expirer = require('expire-unused-keys')
 
 test("something closer to a real implementation, for the readme", function(t) {
 	// Some levelUP db
-	var db = level('wat')
+	var db = level()
 	// Expire stuff after 15 seconds of inactivity
-	var expirer = new Expirer(15000, db)
+	var expirer = new Expirer({ timeoutMs: 15000, db: db })
 
 	// Things are only interesting if they were active in the last 15 seconds
 	var areTheseThingsInteresting = {
 		'thing1': false,
-		'thing2': false
+		'thing2': false,
 	}
 
 	var activity = function(thingKey) {
@@ -39,8 +40,8 @@ test("something closer to a real implementation, for the readme", function(t) {
 		activity('thing1')
 	}, 10 * 1000)
 
-    // thing1 will expire after 25 seconds after the first time it was touched
-    // thing2 will expire 15 seconds after the first time it was touched
+	// thing1 will expire after 25 seconds after the first time it was touched
+	// thing2 will expire 15 seconds after the first time it was touched
 
 	setTimeout(function() {
 		t.notOk(areTheseThingsInteresting['thing2'], "thing2 is not interesting after 16 seconds")

--- a/test/expired_event_emits_1_arg.js
+++ b/test/expired_event_emits_1_arg.js
@@ -1,19 +1,19 @@
+require('loud-rejection')()
 var Expirer = require('../')
 var test = require('tape')
-var level = require('level-mem')
+const level = require('./helpers/level-mem')
 
 test('an expired event should only have 1 argument', function(t) {
 	t.timeoutAfter(2000)
 	t.plan(2)
 
-	var expirer = new Expirer(100, level('roflcopter'))
+	var expirer = new Expirer({ timeoutMs: 100, db: level() })
 
-	expirer.emit('touch', 'hello there')
+	expirer.touch('hello there')
 
-	expirer.on('expire', function() {
-		var argArray = Array.prototype.slice.call(arguments)
-		t.equal(argArray.length, 1, 'should only have 1 argument')
-		t.equal(argArray[0], 'hello there')
+	expirer.on('expire', (...args) => {
+		t.equal(args.length, 1, 'should only have 1 argument')
+		t.equal(args[0], 'hello there')
 
 		expirer.stop()
 		t.end()

--- a/test/helpers/level-mem.js
+++ b/test/helpers/level-mem.js
@@ -1,0 +1,6 @@
+const memdown = require('memdown')
+const levelup = require('levelup')
+const encode = require('encoding-down')
+
+let increment = 0
+module.exports = () => levelup(encode(memdown(increment++)))

--- a/test/immediate_refresh.js
+++ b/test/immediate_refresh.js
@@ -1,17 +1,16 @@
+require('loud-rejection')()
 var Expirer = require('../')
 var test = require('tape')
-var level = require('level-mem')
+const level = require('./helpers/level-mem')
 
 test("Should fire a second time after being touched in an expire callback", function(t) {
-	var expirer = new Expirer(500, level('wat'))
+	var expirer = new Expirer({ timeoutMs: 500, db: level() })
 	var key = "lol I'm a key"
 
-	expirer.emit('touch', key)
+	expirer.touch(key)
 
 	t.plan(2)
 	t.timeoutAfter(3000)
-
-	var done = false
 
 	expirer.once('expire', function() {
 		t.pass('called the first time')
@@ -19,7 +18,6 @@ test("Should fire a second time after being touched in an expire callback", func
 		expirer.once('expire', function() {
 			t.pass('called the second time')
 			expirer.stop()
-			done = true
 			t.end()
 		})
 	})

--- a/test/interval.js
+++ b/test/interval.js
@@ -1,22 +1,23 @@
+require('loud-rejection')()
 var test = require('tape')
-var level = require('level-mem')
+const level = require('./helpers/level-mem')
 
 var Expirer = require('../')
 
 test('repeatExpirations', function(t) {
 	// Some levelUP db
-	var db = level(':)')
+	var db = level()
 	// Expire stuff after 15 seconds of inactivity
 	var expirer = new Expirer({
 		timeoutMs: 200,
-		db: db, 
+		db: db,
 		checkIntervalMs: 20,
-		repeatExpirations: true
+		repeatExpirations: true,
 	})
 
 	// Things are only interesting if they were active in the last 15 seconds
 	var counters = {
-		thing: 0
+		thing: 0,
 	}
 
 	expirer.on('expire', function(thingKey) {

--- a/test/persistence.js
+++ b/test/persistence.js
@@ -1,13 +1,14 @@
+require('loud-rejection')()
 var Expirer = require('../')
 var test = require('tape')
-var level = require('level-mem')
+const level = require('./helpers/level-mem')
 
 test('make sure event fires immediately with a new instantiation created later', function(t) {
-	var db = level('wat')
+	var db = level()
 
 	t.plan(1)
 
-	var expirer = new Expirer(2000, db, 10)
+	var expirer = new Expirer({ timeoutMs: 2000, db, checkIntervalMs: 10 })
 	expirer.touch('thingy')
 	expirer.on('expire', function(key) {
 		t.ok(false, 'Expirer has been stopped and should not emit any expire events')
@@ -15,7 +16,7 @@ test('make sure event fires immediately with a new instantiation created later',
 	expirer.stop()
 
 	setTimeout(function() {
-		var secondExpirer = new Expirer(1000, db, 10)
+		var secondExpirer = new Expirer({ timeoutMs: 1000, db, checkIntervalMs: 10 })
 		secondExpirer.on('expire', function(key) {
 			t.equal('thingy', key, 'Same key as was touched')
 		})
@@ -29,14 +30,14 @@ test('make sure event fires immediately with a new instantiation created later',
 })
 
 test('make sure event fires at the correct time from a different instantiation', function(t) {
-	var db = level('wat')
+	var db = level()
 	var started = new Date().getTime()
-	var expirer = new Expirer(100, db, 5)
+	var expirer = new Expirer({ timeoutMs: 100, db, checkIntervalMs: 5 })
 
 	expirer.touch('sup')
 	expirer.stop()
 
-	var secondExpirer = new Expirer(100, db, 5)
+	var secondExpirer = new Expirer({ timeoutMs: 100, db, checkIntervalMs: 5 })
 
 	t.timeoutAfter(1000)
 

--- a/test/pushing_expiration_back.js
+++ b/test/pushing_expiration_back.js
@@ -1,9 +1,10 @@
+require('loud-rejection')()
 var Expirer = require('../')
 var test = require('tape')
-var level = require('level-mem')
+const level = require('./helpers/level-mem')
 
 test("make sure that calling touch pushes the expiration back", function(t) {
-	var expirer = new Expirer(5000, level('wat'))
+	var expirer = new Expirer({ timeoutMs: 5000, db: level() })
 	var key = 'yo'
 
 	var start = new Date().getTime()
@@ -32,7 +33,7 @@ test("make sure that calling touch pushes the expiration back", function(t) {
 		expirer.touch(key)
 		setTimeout(function() {
 			// After another 1.5 seconds (3.5 total), touch it again
-			expirer.emit('touch', key)
+			expirer.touch(key)
 		}, 1500)
 	}, 2000)
 })

--- a/test/stopping.js
+++ b/test/stopping.js
@@ -1,9 +1,10 @@
+require('loud-rejection')()
 var Expirer = require('../')
 var test = require('tape')
-var level = require('level-mem')
+const level = require('./helpers/level-mem')
 
 test("stopping actually makes it stop", function(t) {
-	var expirer = new Expirer(500, level('wat'))
+	var expirer = new Expirer({ timeoutMs: 500, db: level() })
 	t.plan(2)
 
 	expirer.on('expire', function() {


### PR DESCRIPTION
LevelUP upgrade + Promises + async/await.

I didn't bother modernizing most of the tests.

This is a precursor to upgrading [levelup-cache](https://github.com/TehShrike/levelup-cache/) to be tested with LevelUP 2, and also make it easier to use async/await to eliminate some race conditions in its use of expire-unused-keys.